### PR TITLE
Remove C in df.plot

### DIFF
--- a/src/text_clustering.py
+++ b/src/text_clustering.py
@@ -316,7 +316,6 @@ class ClusterClassifier:
             kind="scatter",
             x="X",
             y="Y",
-            c="labels",
             s=0.75,
             alpha=0.8,
             linewidth=0,


### PR DESCRIPTION
It is not possible to use both the C and the Color paramenter option in dataframe.plot() in the _show_mpl function.
When I run it in Colab it throws an error stating chose exactly one of 'c' or 'color'